### PR TITLE
doc: Added python deprecation warning

### DIFF
--- a/audiostack/__init__.py
+++ b/audiostack/__init__.py
@@ -1,15 +1,24 @@
-sdk_version = "1.3.0"
+sdk_version = "1.3.1"
 api_base = "https://v2.api.audio"
 api_key = None
 assume_org_id = None
 app_info = None
 
 
+from warnings import warn
+
 from audiostack import content as Content
 from audiostack import speech as Speech
 from audiostack import production as Production
 from audiostack import delivery as Delivery
 from audiostack.docs.docs import Documentation
+
+warn(
+    "Future releases (`^2.0.0`) of the AudioStack SDK will only support python `^3.8.1`",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 billing_session = 0
 


### PR DESCRIPTION
As part of poetry upgrade in https://github.com/aflorithmic/audiostack-python/pull/42

We are issuing a deprecation warning to any python <3.8.1 adn they are EOL.

```
[Clang 15.0.0 (clang-1500.0.40.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import audiostack
<stdin>:1: DeprecationWarning: Future releases (`^2.0.0`) of the AudioStack SDK will only support python `^3.8.1`
>>> 
```

 Reference: https://audiostack.slack.com/archives/C01JQ7W3F4J/p1715932910075489