### PR TITLE
bug: Fixed missing x-assume-org header in download_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `audiostack` will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.0] - 2024-05-19
+## [2.0.0] - 2024-05-20
 
 ### Breaking change 
 
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixes
 
 - Fixed missing argument in `content.list_modules`.
+- Fixed inclusion of missing `x-assume-org` header in `request_interface.download_url`.

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -31,7 +31,8 @@ class RequestInterface:
     def __init__(self, family: str) -> None:
         self.family = family
 
-    def make_header(self) -> dict:
+    @staticmethod
+    def make_header() -> dict:
         header = {
             "x-api-key": audiostack.api_key,
             "x-python-sdk-version": audiostack.sdk_version,
@@ -58,15 +59,6 @@ class RequestInterface:
             )
             raise Exception(msg)
 
-        # if isinstance(r.content, bytes):
-        #     if self.DEBUG_PRINT:
-        #         print("Is bytes")
-        #     return {
-        #         "bytes" : r.content,
-        #         "statusCode" : r.status_code
-        #     }
-
-        # else:
         if "meta" in r.json():
             if "creditsUsed" in r.json()["meta"]:
                 audiostack.billing_session += r.json()["meta"]["creditsUsed"]
@@ -140,11 +132,9 @@ class RequestInterface:
                 )
             )
 
-    @staticmethod
-    def download_url(url: str, name: str, destination: str) -> None:
-        r = requests.get(
-            url=url, stream=True, headers={"x-api-key": audiostack.api_key}
-        )
+    @classmethod
+    def download_url(cls, url: str, name: str, destination: str) -> None:
+        r = requests.get(url=url, stream=True, headers=cls.make_header())
 
         if r.status_code >= 400:
             raise Exception("Failed to download file")

--- a/audiostack/tests/helpers/test_request_interface.py
+++ b/audiostack/tests/helpers/test_request_interface.py
@@ -1,0 +1,61 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+import audiostack
+from audiostack.helpers.request_interface import RequestInterface
+
+
+@patch("audiostack.helpers.request_interface.open")
+@patch("audiostack.helpers.request_interface.shutil")
+@patch("audiostack.helpers.request_interface.requests")
+def test_RequestInterface_download_url(
+    mock_requests: Mock, mock_shutil: Mock, mock_open: Mock, tmp_path: str
+) -> None:
+    mock_requests.get.return_value.status_code = 200
+
+    RequestInterface.download_url(url="foo", name="bar", destination=tmp_path)
+    mock_requests.get.assert_called_once_with(
+        url="foo",
+        stream=True,
+        headers={
+            "x-api-key": audiostack.api_key,
+            "x-python-sdk-version": audiostack.sdk_version,
+        },
+    )
+    mock_open.assert_called_once_with(f"{tmp_path}/bar", "wb")
+    mock_shutil.copyfileobj.assert_called_once()
+
+
+@patch("audiostack.helpers.request_interface.open")
+@patch("audiostack.helpers.request_interface.shutil")
+@patch("audiostack.helpers.request_interface.requests")
+def test_RequestInterface_download_url_assume_org(
+    mock_requests: Mock, mock_shutil: Mock, mock_open: Mock, tmp_path: str
+) -> None:
+    mock_requests.get.return_value.status_code = 200
+    audiostack.assume_org_id = "child_org_id"  # type: ignore
+    RequestInterface.download_url(url="foo", name="bar", destination=tmp_path)
+    mock_requests.get.assert_called_once_with(
+        url="foo",
+        stream=True,
+        headers={
+            "x-api-key": audiostack.api_key,
+            "x-python-sdk-version": audiostack.sdk_version,
+            "x-assume-org": "child_org_id",
+        },
+    )
+    mock_open.assert_called_once_with(f"{tmp_path}/bar", "wb")
+    mock_shutil.copyfileobj.assert_called_once()
+
+    # Resetting value after test
+    audiostack.assume_org_id = None  # type: ignore
+
+
+@patch("audiostack.helpers.request_interface.requests")
+def test_RequestInterface_download_url_4XX(
+    mock_requests: Mock,
+) -> None:
+    mock_requests.get.return_value.status_code = 400
+    with pytest.raises(Exception):
+        RequestInterface.download_url(url="foo", name="bar", destination="baz")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "audiostack"
-version = "2.0.0.alpha"
+version = "2.0.0"
 description = "Python SDK for Audiostack API"
 authors = ["Aflorithmic <support@audiostack.ai>"]
 repository = "https://github.com/aflorithmic/audiostack-python"


### PR DESCRIPTION
Successfully ran the original failing example
```
import audiostack

audiostack.api_key = ...  # type: ignore
audiostack.assume_org_id = "AudioStack_ML_Team_Testing_Org-ee46"  # type: ignore


r = audiostack.Content.File.search(path="PVC/25273_ARA_KI Projekt_Seite")


for file_ in r.data["items"]:
    if file_["filePath"].endswith("58__denoised.wav"):
        print(file_["filePath"])
        item = audiostack.Content.File.get(fileId=file_["fileId"])
        item.download(path=".")
```