### PR TITLE
feat: add customer trace id header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Customer trace id header can now be set.
+- Can pass through custom headers into `send_request`.
 
 ## [2.9.0] - 2025-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Customer trace id header can now be set.
+- Customer trace id header can now be set per production using the `use_trace` context manager.
 - Can pass through custom headers into `send_request`.
 
 ## [2.9.0] - 2025-01-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `audiostack` will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.10.0] - 2025-02-13
+
+### Added
+
+- Customer trace id header can now be set.
+
 ## [2.9.0] - 2025-01-23
 
 ### Fixed

--- a/audiostack/__init__.py
+++ b/audiostack/__init__.py
@@ -3,7 +3,6 @@ api_base = "https://v2.api.audio"
 api_key = None
 assume_org_id = None
 app_info = None
-customer_trace_id = None
 
 TIMEOUT_THRESHOLD_S = 300
 

--- a/audiostack/__init__.py
+++ b/audiostack/__init__.py
@@ -3,6 +3,7 @@ api_base = "https://v2.api.audio"
 api_key = None
 assume_org_id = None
 app_info = None
+customer_trace_id = None
 
 TIMEOUT_THRESHOLD_S = 300
 

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -37,6 +37,8 @@ class RequestInterface:
             "x-api-key": audiostack.api_key,
             "x-python-sdk-version": audiostack.sdk_version,
         }
+        if audiostack.customer_trace_id:
+            header["x-customer-trace-id"] = audiostack.customer_trace_id
         if audiostack.assume_org_id:
             header["x-assume-org"] = audiostack.assume_org_id
         return header

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -2,7 +2,7 @@ import contextlib
 import contextvars
 import json
 import shutil
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Generator, Optional, Union
 
 import requests
 
@@ -155,9 +155,8 @@ class RequestInterface:
 
 
 @contextlib.contextmanager
-def use_trace(trace_id):
+def use_trace(trace_id: str) -> Generator[None, None, None]:
     token = _current_trace_id.set(trace_id)
-
     try:
         yield
     finally:

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -1,8 +1,8 @@
+import contextlib
+import contextvars
 import json
 import shutil
 from typing import Any, Callable, Dict, Optional, Union
-import contextlib
-import contextvars
 
 import requests
 

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -156,7 +156,9 @@ class RequestInterface:
 
 @contextlib.contextmanager
 def use_trace(trace_id: str) -> Generator[None, None, None]:
-    token = _current_trace_id.set(trace_id)
+    # This is a workaround to give correct type hints to the context manager but follow ContextVar's .set() method signature
+    any_typed_trace_id: Any = trace_id
+    token = _current_trace_id.set(any_typed_trace_id)
     try:
         yield
     finally:

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -1,7 +1,7 @@
 import contextlib
-from contextvars import ContextVar
 import json
 import shutil
+from contextvars import ContextVar
 from typing import Any, Callable, Dict, Generator, Optional, Union
 
 import requests

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -1,5 +1,5 @@
 import contextlib
-import contextvars
+from contextvars import ContextVar
 import json
 import shutil
 from typing import Any, Callable, Dict, Generator, Optional, Union
@@ -9,7 +9,9 @@ import requests
 import audiostack
 from audiostack.helpers.request_types import RequestTypes
 
-_current_trace_id = contextvars.ContextVar("current_trace_id", default=None)
+_current_trace_id: ContextVar[Optional[str]] = ContextVar(
+    "current_trace_id", default=None
+)
 
 
 def remove_empty(data: Any) -> Any:
@@ -156,9 +158,7 @@ class RequestInterface:
 
 @contextlib.contextmanager
 def use_trace(trace_id: str) -> Generator[None, None, None]:
-    # This is a workaround to give correct type hints to the context manager but follow ContextVar's .set() method signature
-    any_typed_trace_id: Any = trace_id
-    token = _current_trace_id.set(any_typed_trace_id)
+    token = _current_trace_id.set(trace_id)
     try:
         yield
     finally:

--- a/audiostack/helpers/request_interface.py
+++ b/audiostack/helpers/request_interface.py
@@ -32,16 +32,18 @@ class RequestInterface:
         self.family = family
 
     @staticmethod
-    def make_header() -> dict:
-        header = {
+    def make_header(headers: Optional[dict] = None) -> dict:
+        new_headers = {
             "x-api-key": audiostack.api_key,
             "x-python-sdk-version": audiostack.sdk_version,
         }
         if audiostack.customer_trace_id:
-            header["x-customer-trace-id"] = audiostack.customer_trace_id
+            new_headers["x-customer-trace-id"] = audiostack.customer_trace_id
         if audiostack.assume_org_id:
-            header["x-assume-org"] = audiostack.assume_org_id
-        return header
+            new_headers["x-assume-org"] = audiostack.assume_org_id
+        if headers:
+            new_headers.update(headers)
+        return new_headers
 
     def resolve_response(self, r: Any) -> dict:
         if self.DEBUG_PRINT:
@@ -84,6 +86,7 @@ class RequestInterface:
         path_parameters: Optional[Union[dict, str]] = None,
         query_parameters: Optional[Union[dict, str]] = None,
         overwrite_base_url: Optional[str] = None,
+        headers: Optional[dict] = None,
     ) -> Any:
         if overwrite_base_url:
             url = overwrite_base_url
@@ -113,7 +116,7 @@ class RequestInterface:
             }
 
             return self.resolve_response(
-                FUNC_MAP[rtype](url=url, json=json, headers=self.make_header())
+                FUNC_MAP[rtype](url=url, json=json, headers=self.make_header(headers))
             )
         elif rtype == RequestTypes.GET:
             if path_parameters:
@@ -121,7 +124,7 @@ class RequestInterface:
 
             return self.resolve_response(
                 requests.get(
-                    url=url, params=query_parameters, headers=self.make_header()
+                    url=url, params=query_parameters, headers=self.make_header(headers)
                 )
             )
         elif rtype == RequestTypes.DELETE:
@@ -130,7 +133,7 @@ class RequestInterface:
 
             return self.resolve_response(
                 requests.delete(
-                    url=url, params=query_parameters, headers=self.make_header()
+                    url=url, params=query_parameters, headers=self.make_header(headers)
                 )
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "audiostack"
-version = "2.9.1"
+version = "2.10.0"
 description = "Python SDK for Audiostack API"
 authors = ["Aflorithmic <support@audiostack.ai>"]
 repository = "https://github.com/aflorithmic/audiostack-python"


### PR DESCRIPTION
This is a simple change to allow the user to set a trace header so that they can eventually track billing and any other metrics.  Will not work with concurrent requests but avoids passing header arguments around.  Other potential solutions could involve class level fields, and initiating separate objects.

Also I'm not sure if `customer_trace_id` is the best thing to call the customer facing variable.  Our header name will stay the same but maybe just `trace_id` might be better, thoughts?

I've also added a way to pass through custom headers, this is for when we want to pass through headers set by the FE.