### PR TITLE
implement timeout retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `audiostack` will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.0] - 2025-08-04
+- Users are now able to specify the number of retries they would like in an event of a timeout with the aim to provide better automation.
+- Added a small delay inbetween GET requests for speech response to prevent hammering servers.
+
 ## [3.0.0] - 2025-07-29
 
 ### 🆕 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.1.0] - 2025-08-04
+
+### Added
+
 - Users are now able to specify the number of retries they would like in an event of a timeout with the aim to provide better automation.
-- Added a small delay inbetween GET requests for speech response to prevent hammering servers.
+- Users can also specify the timeout threshold with the default value being 300 seconds (5 minutes)
+- Added a small delay in between GET requests for speech response to prevent hammering servers.
 
 ## [3.0.0] - 2025-07-29
 

--- a/audiostack/speech/tts.py
+++ b/audiostack/speech/tts.py
@@ -157,6 +157,7 @@ class TTS:
         useDenoiser: bool = False,
         useAutofix: bool = False,
         timeoutRetries: int = 0,
+        timeoutThreshold: int = TIMEOUT_THRESHOLD_S,
     ) -> "TTS.Item":
         # (start) no modify
         route = "tts"
@@ -216,6 +217,7 @@ class TTS:
         useCache: bool = True,
         useDenoiser: bool = False,
         timeoutRetries: int = 0,
+        timeoutThreshold: int = TIMEOUT_THRESHOLD_S,
     ) -> "TTS.Item":
         if scriptId and scriptItem:
             raise Exception("scriptId or scriptItem should be supplied not both")
@@ -261,7 +263,7 @@ class TTS:
                 query_parameters={"public": public},
             )
 
-            if time.time() - start >= TIMEOUT_THRESHOLD_S:
+            if time.time() - start >= timeoutThreshold:
                 if attempts < timeoutRetries:
                     r = TTS.interface.send_request(
                         rtype=RequestTypes.POST, route="tts", json=body
@@ -269,7 +271,7 @@ class TTS:
                     start = time.time()
                 else:
                     raise TimeoutError(
-                        f'Polling TTS timed out after 5 minutes and max number of retries reached. Please contact us for support. SpeechId: {r["data"]["speechId"]}'
+                        f'Polling TTS timed out after {timeoutThreshold} seconds and max number of retries reached. Please contact us for support. SpeechId: {r["data"]["speechId"]}'
                     )
                 attempts += 1
             time.sleep(0.05)

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -8,7 +8,7 @@ import audiostack
 audiostack.api_base = os.environ.get(
     "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
 )
-audiostack.api_key = os.environ["AUDIO_STACK_DEV_KEY"]
+audiostack.api_key = os.environ.get("AUDIO_STACK_DEV_KEY", "")
 
 
 @pytest.fixture

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -8,7 +8,9 @@ import audiostack
 audiostack.api_base = os.environ.get(
     "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
 )
-API_KEY: str = os.environ.get("AUDIO_STACK_DEV_KEY", "")
+API_KEY: str = (
+    os.environ["AUDIO_STACK_DEV_KEY"] if "AUDIO_STACK_DEV_KEY" in os.environ else ""
+)
 audiostack.api_key = API_KEY
 
 

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -8,7 +8,7 @@ import audiostack
 audiostack.api_base = os.environ.get(
     "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
 )
-API_KEY = os.environ.get("AUDIO_STACK_DEV_KEY", "")
+API_KEY: str = os.environ.get("AUDIO_STACK_DEV_KEY", "")
 audiostack.api_key = API_KEY
 
 

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 from typing import Generator
+
 import pytest
 
 import audiostack

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -8,7 +8,8 @@ import audiostack
 audiostack.api_base = os.environ.get(
     "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
 )
-audiostack.api_key = os.environ.get("AUDIO_STACK_DEV_KEY", "")
+API_KEY = os.environ.get("AUDIO_STACK_DEV_KEY", "")
+audiostack.api_key = API_KEY
 
 
 @pytest.fixture

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+from typing import Generator
+import pytest
+
+import audiostack
+
+audiostack.api_base = os.environ.get(
+    "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
+)
+audiostack.api_key = os.environ["AUDIO_STACK_DEV_KEY"]
+
+
+@pytest.fixture
+def script_item() -> Generator[audiostack.Content.Script.Item, None, None]:
+    script = audiostack.Content.Script.create(scriptText="hello sam")
+    yield script
+    audiostack.Content.Script.delete(scriptId=script.scriptId)
+
+
+@pytest.fixture
+def speech_item(
+    script_item: audiostack.Content.Script.Item,
+) -> Generator[audiostack.Speech.TTS.Item, None, None]:
+    tts = audiostack.Speech.TTS.create(
+        scriptId=script_item.scriptId,
+        voice="isaac",
+    )
+    yield tts
+    audiostack.Speech.TTS.delete(speechId=tts.speechId)

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -8,7 +8,7 @@ import audiostack
 audiostack.api_base = os.environ.get(
     "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
 )
-audiostack.api_key = os.environ.get("AUDIO_STACK_DEV_KEY", None)
+audiostack.api_key = os.environ.get("AUDIO_STACK_DEV_KEY", None)  # type: ignore
 
 
 @pytest.fixture

--- a/audiostack/tests/conftest.py
+++ b/audiostack/tests/conftest.py
@@ -8,10 +8,7 @@ import audiostack
 audiostack.api_base = os.environ.get(
     "AUDIO_STACK_DEV_URL", "https://staging-v2.api.audio"
 )
-API_KEY: str = (
-    os.environ["AUDIO_STACK_DEV_KEY"] if "AUDIO_STACK_DEV_KEY" in os.environ else ""
-)
-audiostack.api_key = API_KEY
+audiostack.api_key = os.environ.get("AUDIO_STACK_DEV_KEY", None)
 
 
 @pytest.fixture

--- a/audiostack/tests/production/test_mix.py
+++ b/audiostack/tests/production/test_mix.py
@@ -2,6 +2,7 @@ import time
 from unittest.mock import Mock, patch
 
 import pytest
+
 from audiostack.content.script import Script
 from audiostack.production.mix import Mix
 from audiostack.speech.tts import TTS

--- a/audiostack/tests/production/test_mix.py
+++ b/audiostack/tests/production/test_mix.py
@@ -1,0 +1,96 @@
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+from audiostack.content.script import Script
+from audiostack.production.mix import Mix
+from audiostack.speech.tts import TTS
+
+
+def test_create_production_with_speech_id(speech_item: TTS.Item) -> None:
+    """Test creating a speech item."""
+    mix_item = Mix.create(
+        speechId=speech_item.speechId,
+    )
+    assert isinstance(mix_item, Mix.Item)
+
+
+def test_create_production_with_speech_item(speech_item: TTS.Item) -> None:
+    """Test creating a production item with speechItem."""
+    mix_item = Mix.create(
+        speechItem=speech_item,
+    )
+    assert isinstance(mix_item, Mix.Item)
+
+
+def test_script_id_and_speech_item_conflict(
+    speech_item: TTS.Item, script_item: Script.Item
+) -> None:
+    """Test that an exception is raised when both scriptId and speechItem are provided."""
+    try:
+        Mix.create(
+            scriptId=script_item.scriptId,
+            speechItem=speech_item,
+        )
+    except Exception as e:
+        assert (
+            str(e)
+            == "only 1 of the following is required; speechId, speechItem, or scriptId"
+        )
+    else:
+        assert False, "Expected an exception to be raised"
+
+
+def test_create_production_no_script_id_or_item() -> None:
+    """Test that an exception is raised when neither scriptId nor speechItem is provided."""
+    try:
+        Mix.create()
+    except Exception as e:
+        assert (
+            str(e)
+            == "only 1 of the following is required; speechId, speechItem, or scriptId"
+        )
+    else:
+        assert False, "Expected an exception to be raised"
+
+
+@patch("audiostack.production.mix.Mix.interface.send_request")
+def test_create_production_with_different_timeout(mock_send_request: Mock) -> None:
+    """Test creating a production item with a different timeout."""
+    mock_send_request.return_value = {
+        "statusCode": 202,
+        "data": {"productionId": "123"},
+    }
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        Mix.create(
+            speechId="some_speech_id",
+            timeoutThreshold=2,
+        )
+    elapsed_time = time.time() - start
+    assert (
+        2 < elapsed_time < 2.5
+    )  # Allow a small margin for the time taken to raise the exception
+
+
+@patch("audiostack.production.mix.Mix.interface.send_request")
+def test_create_production_with_timeout_retries(
+    mock_send_request: Mock, speech_item: TTS.Item
+) -> None:
+    """Test creating a production item with retries on timeout."""
+    mock_send_request.return_value = {
+        "statusCode": 202,
+        "data": {"productionId": "123"},
+    }
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        Mix.create(
+            speechId=speech_item.speechId,
+            timeoutRetries=3,
+            timeoutThreshold=2,
+        )
+    elapsed_time = time.time() - start
+    # The total time should be more than 8 seconds due to 4 attempts (initial + 3 retries) and 2 seconds per attempt
+    assert (
+        8 < elapsed_time < 8.5
+    )  # Allow a small margin for the time taken to raise the exception

--- a/audiostack/tests/tts/test_tts.py
+++ b/audiostack/tests/tts/test_tts.py
@@ -1,0 +1,84 @@
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+from audiostack.content.script import Script
+from audiostack.speech.tts import TTS
+
+
+def test_create_speech_with_script_id(script_item: Script.Item) -> None:
+    """Test creating a speech item."""
+    speech_item = TTS.create(
+        scriptId=script_item.scriptId,
+        voice="isaac",
+    )
+    assert isinstance(speech_item, TTS.Item)
+
+
+def test_create_speech_with_script_item(script_item: Script.Item) -> None:
+    """Test creating a speech item."""
+    speech_item = TTS.create(
+        scriptItem=script_item,
+        voice="isaac",
+    )
+    assert isinstance(speech_item, TTS.Item)
+
+
+def test_script_id_and_script_item_conflict(script_item: Script.Item) -> None:
+    """Test that an exception is raised when both scriptId and scriptItem are provided."""
+    try:
+        TTS.create(
+            scriptId=script_item.scriptId,
+            scriptItem=script_item,
+            voice="isaac",
+        )
+    except Exception as e:
+        assert str(e) == "scriptId or scriptItem should be supplied not both"
+    else:
+        assert False, "Expected an exception to be raised"
+
+
+def test_create_speech_no_script_id_or_item() -> None:
+    """Test that an exception is raised when neither scriptId nor scriptItem is provided."""
+    try:
+        TTS.create(voice="isaac")
+    except Exception as e:
+        assert str(e) == "scriptId or scriptItem should be supplied"
+    else:
+        assert False, "Expected an exception to be raised"
+
+
+@patch("audiostack.speech.tts.TTS.interface.send_request")
+def test_create_speech_with_different_timeout(
+    mock_send_request: Mock, script_item: Script.Item
+) -> None:
+    """Test creating a speech item with a different timeout."""
+    mock_send_request.return_value = {"statusCode": 202, "data": {"speechId": "123"}}
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        TTS.create(
+            scriptId=script_item.scriptId,
+            voice="isaac",
+            timeoutThreshold=2,
+        )
+    elapsed = time.time() - start
+    assert 2 < elapsed < 2.5  # Allow a small margin for the timeout to trigger
+
+
+@patch("audiostack.speech.tts.TTS.interface.send_request")
+def test_create_speech_with_retries(
+    mock_send_request: Mock, script_item: Script.Item
+) -> None:
+    """Test creating a speech item with retries."""
+    mock_send_request.return_value = {"statusCode": 202, "data": {"speechId": "123"}}
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        TTS.create(
+            scriptId=script_item.scriptId,
+            voice="isaac",
+            timeoutThreshold=2,
+            timeoutRetries=3,
+        )
+    elapsed = time.time() - start
+    # The total time should be more than 8 seconds due to 4 attempts (initial + 3 retries) and 2 seconds per attempt
+    assert 8 < elapsed < 8.5  # Allow a small margin for the retries to complete

--- a/audiostack/tests/tts/test_tts.py
+++ b/audiostack/tests/tts/test_tts.py
@@ -2,6 +2,7 @@ import time
 from unittest.mock import Mock, patch
 
 import pytest
+
 from audiostack.content.script import Script
 from audiostack.speech.tts import TTS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "audiostack"
-version = "3.0.0"
+version = "3.1.0"
 description = "Python SDK for Audiostack API"
 authors = ["Aflorithmic <support@audiostack.ai>"]
 repository = "https://github.com/aflorithmic/audiostack-python"


### PR DESCRIPTION
Gives the user the ability to specify number of timeout retries with the default being 0 as not to affect any existing workflows.

I have also included a small delay to the polling to reduce hammering the server.