### PR TITLE
Fix/Added handling for nested status codes

### DIFF
--- a/audiostack/audioform/audioform.py
+++ b/audiostack/audioform/audioform.py
@@ -20,10 +20,18 @@ class Audioform:
 
             if "data" in response and response["data"]:
                 # Standard response with data field
-                self.audioform_id = response["data"].get("audioformId", "")
-                self.audioform = response["data"].get("audioform", {})
-                self.result = response["data"].get("result", {})
-                self._errors = response["data"].get("errors", [])
+                data = response["data"]
+                self.audioform_id = data.get("audioformId", "")
+                self.audioform = data.get("audioform", {})
+                self.result = data.get("result", {})
+                self._errors = data.get("errors", [])
+
+                # Handle nested status code
+                self.status_code = data.get("statusCode", self.status_code)
+
+                if self.status_code not in (200, 202) and not self._errors:
+                    message = data.get("message", "")
+                    self._errors = [message] if message else []
             elif "audioformId" in response:
                 # In-progress response with audioformId directly in response
                 self.audioform_id = response.get("audioformId", "")
@@ -64,7 +72,7 @@ class Audioform:
         @property
         def is_failed(self) -> bool:
             """Check if the audioform processing failed"""
-            return self.status_code == 200 and bool(self._errors)
+            return self.status_code != 202 and not self.is_success
 
         @property
         def is_in_progress(self) -> bool:


### PR DESCRIPTION
# Description

# :hammer_and_wrench: Changes being made
Found a case where a failed audioform build was not being handled properly.

The API can return a top-level success response, but still include a failed build status inside data.statusCode. In that case, Audioform.Item could still look successful, and downstream code could crash later when it tried to use fields that were not present in the failed result.
In Story.Item, this is being handled correctly, see [here](https://github.com/aflorithmic/audiostack-python/blob/c61986d297732b691993f4cf9fac4662cc1037bb/audiostack/creator/story.py#L23-L48))

# :microscope: Test Plan

How do you know the changes are safe to ship?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B


# :ticket: Asanaticket 
- [ ] Is the PR attached to the Asanaticket

If there is no Asanaticket for the PR, please describe in 1-2 sentences why there is no ticket for the purposed changes.


# :flight_departure: Quality Check

Please delete options that are not relevant!

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Do we need to implement analytics?
- [ ] Authorization enabled?
- [ ] Do we have monitoring enabled?
- [ ] Is the Postman collection up-to-date.
- [ ] Readme of the Repo updated.
- [ ] This change requires a documentation update

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Is the architecture diagram updated.